### PR TITLE
Updated documentation to reference tile version 1.2.1 and release date

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -26,11 +26,11 @@ The following table provides version and version-support information about Dynat
     <th>Details</th>
     <tr>
         <td>Version</td>
-        <td>v1.2</td>
+        <td>v1.2.1</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>December 7, 2016</td>
+        <td>April 26, 2017</td>
     </tr>
     <tr>
         <td>Software component version</td>
@@ -38,11 +38,11 @@ The following table provides version and version-support information about Dynat
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>
-        <td>v1.7, v1.8</td>
+        <td>v1.8.x, 1.9.x, 1.10.x</td>
     </tr>
     <tr>
         <td>Compatible Elastic Runtime version(s)</td>
-        <td>v1.7.x, v1.8.x</td>
+        <td>v1.8.x, v1.9.x, v1.10.x</td>
     </tr>
     <tr>
         <td>IaaS support</td>

--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -38,7 +38,7 @@ The following table provides version and version-support information about Dynat
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>
-        <td>v1.8.x, 1.9.x, 1.10.x</td>
+        <td>v1.8.x, v1.9.x, v1.10.x</td>
     </tr>
     <tr>
         <td>Compatible Elastic Runtime version(s)</td>
@@ -50,7 +50,7 @@ The following table provides version and version-support information about Dynat
     </tr>
 </table>
 
-## <a id="upgrading"></a> Upgrading v 1.0
+## <a id="upgrading"></a> Upgrading v1.0
 
 The Dynatrace Service Broker for PCF tile replaces both the Dynatrace AppMon Service Broker for PCF v1.0, as well as the Dynatrace Ruxit Service Broker for PCF v1.0 tiles. You must uninstall the previous tiles before installing the new one.
 


### PR DESCRIPTION
We are looking to push a simple new release of the tile to PivNet and need to update the documentation to reflect the new versioning. This tile was simply repackaging the existing tile with 1.8 compatible metadata. 