### PR TITLE
updating version matrix

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -55,15 +55,15 @@ The following table provides version and version-support information about Dynat
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>
-        <td>v1.8.x, v1.9.x, v1.10.x, v1.11.x, v1.12.x, and v2.0.x</td>
+        <td>v1.12.x, v2.0.x, v2.1.x, and v2.2.x</td>
     </tr>
     <tr>
         <td>Compatible Pivotal Application Service version(s)</td>
-        <td>v1.8.x, v1.9.x, v1.10.x, v1.11.x, v1.12.x, and v2.0.x</td>
+        <td>v1.12.x, v2.0.x, v2.1.x, and v2.2.x</td>
     </tr>
     <tr>
         <td>IaaS support</td>
-        <td>AWS, OpenStack, and vSphere</td>
+        <td>AWS, Azure, GCP, OpenStack, and vSphere</td>
     </tr>
 </table>
  


### PR DESCRIPTION
Per our email chain:

Current Dynatrace service broker supports OpsMan + PAS through 2.2.x and all IaaS vendors without code change.